### PR TITLE
Fix duplicate cookie domain & subdomain issue with deriv.com

### DIFF
--- a/public/scripts/cookie.js
+++ b/public/scripts/cookie.js
@@ -1,15 +1,13 @@
 /* utility functions */
 const getDomain = () => {
-  const domain = location.hostname;
+  const host_domain = location.hostname;
   const allowed_domains = ["deriv.com", "binary.sx"];
 
-  if (allowed_domains.includes(domain) && domain.includes("deriv.com")) {
-    return "deriv.com";
-  }
+  const matched_domain = allowed_domains.find((allowed_domain) =>
+    host_domain.includes(allowed_domain)
+  );
 
-  return allowed_domains.includes(domain) && domain.includes("binary.sx")
-    ? "binary.sx"
-    : domain;
+  return matched_domain ?? domain;
 };
 
 const eraseCookie = (name) => {


### PR DESCRIPTION
Fixed an issue whereby there are two cookies, `.deriv.com` (domain cookie) and `.p2p.deriv.com` (subdomain cookie) which affects UTM tracking