### PR TITLE
Adrienne / Resolved bug where the host domain is not returned in cookie

### DIFF
--- a/public/scripts/cookie.js
+++ b/public/scripts/cookie.js
@@ -7,7 +7,7 @@ const getDomain = () => {
     host_domain.includes(allowed_domain)
   );
 
-  return matched_domain ?? domain;
+  return matched_domain ?? host_domain;
 };
 
 const eraseCookie = (name) => {


### PR DESCRIPTION
Fixed an issue whereby the `host_domain` variable is not returned, thus resulting in `deriv.be` not being tracked