### PR TITLE
chore: add temp_gid cookie

### DIFF
--- a/public/scripts/cookie/v1.0.1.js
+++ b/public/scripts/cookie/v1.0.1.js
@@ -224,6 +224,10 @@ const shouldOverwrite = (new_utm_data, current_utm_data) => {
   if (!!final_gclid) {
     eraseCookie("gclid");
     document.cookie = `gclid=${final_gclid};domain=${getDomain()}; path=/; SameSite=None; Secure;`;
+
+    // TEMP: remove this after testing
+    eraseCookie("temp_gid");
+    document.cookie = `temp_gid=${final_gclid};domain=${getDomain()}; path=/; SameSite=None; Secure;`;
   }
   /* end handling gclid */
 })();


### PR DESCRIPTION
## Motivation:
We are adding a temporary cookie to store the `gclid` as part of testing the theory that some ad blockers may block cookies with recognizable names, such as those related to Google campaign IDs.