### PR TITLE
Potential fix for code scanning alert no. 294: Incomplete URL substring sanitization

### DIFF
--- a/public/email/crowdin/forex-ebook-en.html
+++ b/public/email/crowdin/forex-ebook-en.html
@@ -536,7 +536,7 @@ cacheTrackEvents
           var deriv_cookie_domain = 'deriv.com' // Modify as per your actual usage
           var CookieStorage = function (cookie_name, cookie_domain = '') {
               var hostname = window.location.hostname
-              var is_deriv_com = hostname.includes('deriv.com')
+              var is_deriv_com = isAllowedDomain(hostname)
               this.initialized = false
               this.cookie_name = cookie_name
               this.domain = is_deriv_com ? deriv_cookie_domain : cookie_domain || hostname
@@ -640,6 +640,11 @@ cacheTrackEvents
           var exampleCookies = getCookiesObject(['utm_source', 'utm_campaign'])
           var dataObj = getDataObjFromCookies(exampleCookies, getCookiesFields())
           var dataLink = getDataLink(dataObj)
+      }
+      // Helper function to validate allowed domains
+      function isAllowedDomain(hostname) {
+          const allowedDomains = ['deriv.com'];
+          return allowedDomains.some(domain => hostname === domain || hostname.endsWith(`.${domain}`));
       }
       // Load js-cookie and setup cookies after it's loaded
       loadJSCookie(setupCookies)


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/deriv-static-content/security/code-scanning/294](https://github.com/deriv-com/deriv-static-content/security/code-scanning/294)

To fix the issue, we need to replace the substring check (`hostname.includes('deriv.com')`) with a more secure method that ensures the hostname matches `deriv.com` or its subdomains explicitly. This can be achieved by parsing the hostname and verifying it against a whitelist of allowed domains. The `endsWith` method can be used to ensure that the hostname ends with `.deriv.com` or is exactly `deriv.com`.

Changes to be made:
1. Replace the `hostname.includes('deriv.com')` check with a function that validates the hostname against a whitelist of allowed domains.
2. Add a helper function to perform this validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
