### PR TITLE
Potential fix for code scanning alert no. 286: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "image-size": "^2.0.0",
-    "nodemailer": "^6.9.16"
+    "nodemailer": "^6.9.16",
+    "express-rate-limit": "^7.5.0"
   }
 }

--- a/public/automation/move-file/move-file-server.js
+++ b/public/automation/move-file/move-file-server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const fs = require('fs').promises;
+const rateLimit = require('express-rate-limit');
 const path = require('path');
 const { exec } = require('child_process');
 const util = require('util');
@@ -174,7 +175,13 @@ app.post('/update-socials', async (req, res) => {
     }
 });
 
-app.post('/move-file', async (req, res) => {
+const moveFileLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // Limit each IP to 100 requests per windowMs
+    message: { error: 'Too many requests, please try again later.' }
+});
+
+app.post('/move-file', moveFileLimiter, async (req, res) => {
     const { sourcePath, destPath } = req.body;
 
     try {


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/deriv-static-content/security/code-scanning/286](https://github.com/deriv-com/deriv-static-content/security/code-scanning/286)

To address the issue, we will introduce rate limiting to the `/move-file` endpoint using the `express-rate-limit` package. This middleware will restrict the number of requests a client can make to the endpoint within a specified time window. For example, we can allow a maximum of 100 requests per 15 minutes per client. This will mitigate the risk of DoS attacks while maintaining functionality for legitimate users.

Steps to implement the fix:
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the file.
3. Define a rate limiter with appropriate configuration (e.g., 100 requests per 15 minutes).
4. Apply the rate limiter to the `/move-file` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
