### PR TITLE
Potential fix for code scanning alert no. 358: Missing rate limiting

### DIFF
--- a/public/automation/move-file/move-file-server.js
+++ b/public/automation/move-file/move-file-server.js
@@ -156,7 +156,13 @@ async function updateSocialLinks(filePath, language) {
     }
 }
 
-app.post('/update-socials', async (req, res) => {
+const updateSocialsLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // Limit each IP to 100 requests per windowMs
+    message: { error: 'Too many requests, please try again later.' }
+});
+
+app.post('/update-socials', updateSocialsLimiter, async (req, res) => {
     console.log('Received update-socials request:', req.body);
     const { filePath, language } = req.body;
     const resolvedPath = path.resolve(SAFE_ROOT, filePath);


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/deriv-static-content/security/code-scanning/358](https://github.com/deriv-com/deriv-static-content/security/code-scanning/358)

To address the issue, we will introduce rate limiting to the `/update-socials` endpoint using the `express-rate-limit` package, which is already imported in the file. This will limit the number of requests that can be made to the endpoint within a specified time window, mitigating the risk of DoS attacks.

- Define a rate limiter specifically for the `/update-socials` endpoint.
- Apply the rate limiter middleware to the `/update-socials` route.
- Ensure the rate limiter configuration aligns with the application's security and performance requirements.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
