### PR TITLE
Potential fix for code scanning alert no. 280: Client-side cross-site scripting

### DIFF
--- a/public/automation/sendemail-fromlocal/sendemail-local.js
+++ b/public/automation/sendemail-fromlocal/sendemail-local.js
@@ -2,6 +2,7 @@ const nodemailer = require('nodemailer');
 const express = require('express');
 const cors = require('cors');
 const axios = require('axios');
+const sanitizeHtml = require('sanitize-html');
 const app = express();
 
 app.use(cors());
@@ -18,11 +19,13 @@ const transporter = nodemailer.createTransport({
 app.post('/send-email', (req, res) => {
     const { to, subject, htmlContent } = req.body;
 
+    const sanitizedHtmlContent = sanitizeHtml(htmlContent);
+
     const mailOptions = {
         from: 'behnaz1rahgozar1@gmail.com',
         to: to,
         subject: subject || 'HTML Email',
-        html: htmlContent
+        html: sanitizedHtmlContent
     };
 
     transporter.sendMail(mailOptions, (error, info) => {


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/deriv-static-content/security/code-scanning/280](https://github.com/deriv-com/deriv-static-content/security/code-scanning/280)

To fix the issue, we need to sanitize the `htmlContent` variable before using it in the `html` property of the `mailOptions` object. This can be achieved by using a library like `sanitize-html`, which removes potentially dangerous HTML and JavaScript from user-provided content. The fix involves:

1. Installing the `sanitize-html` library.
2. Importing the library into the file.
3. Sanitizing the `htmlContent` variable before assigning it to the `html` property.

This ensures that only safe HTML content is included in the email, mitigating the risk of HTML injection.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
