### PR TITLE
Potential fix for code scanning alert no. 271: DOM text reinterpreted as HTML

### DIFF
--- a/public/landinPage/webflow-forex-ebook-pt.html
+++ b/public/landinPage/webflow-forex-ebook-pt.html
@@ -1576,9 +1576,9 @@
                   .socketMessageSend(JSON.stringify(data), 'verify_email')
                   .then(res => {
                       if (language && language !== 'en') {
-                          window.location.href = `/${language}/verify-email?email=${email}`
+                          window.location.href = `/${language}/verify-email?email=${encodeURIComponent(email)}`
                       } else {
-                          window.location.href = `/verify-email?email=${email}`
+                          window.location.href = `/verify-email?email=${encodeURIComponent(email)}`
                       }
                   })
                   .catch(error => {


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/deriv-static-content/security/code-scanning/271](https://github.com/deriv-com/deriv-static-content/security/code-scanning/271)

To fix the issue, the `email` value should be sanitized or encoded before being used in the URL. The best approach is to use `encodeURIComponent`, which ensures that special characters in the `email` value are properly escaped, preventing them from being interpreted as HTML or JavaScript.

**Steps to fix:**
1. Replace the direct usage of `email` in the URL with `encodeURIComponent(email)`.
2. Ensure that this change is applied consistently wherever `email` is used in constructing URLs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
