### PR TITLE
Potential fix for code scanning alert no. 207: DOM text reinterpreted as HTML

### DIFF
--- a/public/landingpage/crowdin/webflow-forex-ebook.html
+++ b/public/landingpage/crowdin/webflow-forex-ebook.html
@@ -1575,9 +1575,9 @@
                     .socketMessageSend(JSON.stringify(data), 'verify_email')
                     .then(res => {
                         if (language && language !== 'en') {
-                            window.location.href = `/${language}/verify-email?email=${email}`
+                            window.location.href = `/${language}/verify-email?email=${encodeURIComponent(email)}`
                         } else {
-                            window.location.href = `/verify-email?email=${email}`
+                            window.location.href = `/verify-email?email=${encodeURIComponent(email)}`
                         }
                     })
                     .catch(error => {


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/deriv-static-content/security/code-scanning/207](https://github.com/deriv-com/deriv-static-content/security/code-scanning/207)

To fix the issue, the `email` value should be sanitized or encoded before being interpolated into the URL. Specifically, the `encodeURIComponent` function should be used to encode the `email` value. This function ensures that special characters in the email (e.g., `<`, `>`, `&`, `'`, `"`, etc.) are safely encoded, preventing them from being interpreted as HTML or JavaScript.

The fix involves:
1. Modifying the interpolation of the `email` variable in the URL on line 1578 to use `encodeURIComponent(email)`.
2. Ensuring that the same encoding is applied to the `email` variable on line 1580 for consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
