### PR TITLE
Prince/add cookie status

### DIFF
--- a/public/scripts/packages/marketing/package.json
+++ b/public/scripts/packages/marketing/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@deriv-com/marketing-utils",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "type": "module",
     "repository": {
         "type": "git",

--- a/public/scripts/packages/marketing/src/cookie.js
+++ b/public/scripts/packages/marketing/src/cookie.js
@@ -338,6 +338,63 @@
     return stringifiedCookies;
   };
 
+  const testCookieFunctionality = () => {
+    try {
+      // Test basic cookie functionality
+      document.cookie = "deriv_test_cookie=1; SameSite=None; Secure";
+      const test_result = document.cookie.includes("deriv_test_cookie=");
+
+      // Gather browser and cookie configuration info
+      const cookieInfo = {
+        status: test_result ? "enabled" : "disabled",
+        browser: {
+          userAgent: navigator.userAgent,
+          platform: navigator.platform,
+          vendor: navigator.vendor,
+        },
+        cookieConfig: {
+          sameSite: "None",
+          secure: true,
+          domain: getDomain(),
+        },
+        cookieSettings: {
+          thirdPartyCookies: test_result ? "supported" : "blocked",
+          cookieEnabled: navigator.cookieEnabled,
+          doNotTrack: navigator.doNotTrack || window.doNotTrack,
+        },
+        storage: {
+          localStorage: (() => {
+            try {
+              localStorage.setItem("test", "test");
+              localStorage.removeItem("test");
+              return "supported";
+            } catch (e) {
+              return "blocked";
+            }
+          })(),
+          sessionStorage: (() => {
+            try {
+              sessionStorage.setItem("test", "test");
+              sessionStorage.removeItem("test");
+              return "supported";
+            } catch (e) {
+              return "blocked";
+            }
+          })(),
+        }
+      };
+
+      if (!test_result) {
+        console.warn("⚠️ Cookies not stored - possibly ITP or blocked.");
+      }
+
+      return JSON.stringify(cookieInfo);
+    } catch (e) {
+      console.warn("❌ Cookie setting failed:", e);
+      return `error: ${e.message || e.toString()}`;
+    }
+  };
+
   const waitForTrackEvent = (retries = 150, interval = 1000) => {
     const getTrackEventFn = () => {
       return window.Analytics?.trackEvent instanceof Function
@@ -354,6 +411,7 @@
         console.warn("Marketing cookies has been handled");
         trackEvent("debug_marketing_cookies", {
           marketing_cookies: getStringifiedCookies(),
+          cookie_status: testCookieFunctionality(),
         });
       }, 1000);
     } else if (retries > 0) {


### PR DESCRIPTION
Sample log format: 


```
{
  "status": "enabled",
  "browser": {
    "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
    "platform": "MacIntel",
    "vendor": "Google Inc."
  },
  "cookieConfig": {
    "sameSite": "None",
    "secure": true,
    "domain": "deriv.com"
  },
  "cookieSettings": {
    "thirdPartyCookies": "supported",
    "cookieEnabled": true
  },
  "storage": {
    "localStorage": "supported",
    "sessionStorage": "supported"
  }
}
```