### PR TITLE
Potential fix for code scanning alert no. 360: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/request-merge.yml
+++ b/.github/workflows/request-merge.yml
@@ -1,5 +1,9 @@
 name: Notify Slack on Merge Request
 
+permissions:
+  contents: read
+  pull-requests: read
+
 on:
   issue_comment:
     types: [created]


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/deriv-static-content/security/code-scanning/360](https://github.com/deriv-com/deriv-static-content/security/code-scanning/360)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow only reads metadata about pull requests and comments, it only needs `contents: read` and `pull-requests: read` permissions. These permissions will ensure the `GITHUB_TOKEN` has the least privilege necessary to execute the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
